### PR TITLE
Provide Go API by separating CLI from library

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,8 @@ before:
     - go mod tidy
     - go generate ./...
 builds:
-  - env:
+  - main: ./cmd/tandem
+    env:
       - CGO_ENABLED=0
     goos:
       - linux

--- a/ansi/ansi.go
+++ b/ansi/ansi.go
@@ -1,0 +1,57 @@
+// Package ansi provides ANSI escape codes for color and formatting.
+package ansi
+
+import (
+	"fmt"
+	"os"
+)
+
+// NoColor disables ANSI color output. By default it is set to true if the
+// NO_COLOR environment variable is set.
+var NoColor = os.Getenv("NO_COLOR") != ""
+
+// Red returns a string wrapped in ANSI escape codes to make it red.
+func Red(s string) string {
+	if NoColor {
+		return s
+	}
+	return "\033[0;31m" + s + "\033[0m"
+}
+
+// Gray returns a string wrapped in ANSI escape codes to make it gray.
+func Gray(s string) string {
+	if NoColor {
+		return s
+	}
+	return "\033[0;38;5;8m" + s + "\033[0m"
+}
+
+// Dim returns a string wrapped in ANSI escape codes to make it dim.
+func Dim(s string) string {
+	if NoColor {
+		return s
+	}
+	return "\033[0;2m" + s + "\033[0m"
+}
+
+// Bold returns a string wrapped in ANSI escape codes to make it bold.
+func Bold(s string) string {
+	if NoColor {
+		return s
+	}
+	return "\033[1m" + s + "\033[0m"
+}
+
+func ColorStart(i int) string {
+	if NoColor {
+		return ""
+	}
+	return fmt.Sprintf("\033[0;38;5;%vm", i)
+}
+
+func ColorEnd() string {
+	if NoColor {
+		return ""
+	}
+	return "\033[0m"
+}

--- a/cmd/tandem/tandem.go
+++ b/cmd/tandem/tandem.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 
+	"github.com/rosszurowski/tandem/ansi"
+	"github.com/rosszurowski/tandem/tandem"
 	"github.com/urfave/cli/v2"
 )
 
@@ -60,17 +61,12 @@ func main() {
 			if args.Len() < 1 {
 				return ErrNoCommands
 			}
-
-			root, err := filepath.Abs(c.String("directory"))
-			if err != nil {
-				return fmt.Errorf("could not get absolute path for directory: %v", err)
-			}
-			pm, err := newProcessManager(
-				root,
-				c.Int("timeout"),
-				args.Slice(),
-				c.Bool("silent"),
-			)
+			pm, err := tandem.New(tandem.Config{
+				Cmds:    args.Slice(),
+				Root:    c.String("directory"),
+				Timeout: c.Int("timeout"),
+				Silent:  c.Bool("silent"),
+			})
 			if err != nil {
 				return err
 			}
@@ -85,9 +81,9 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		if errors.Is(err, ErrNoCommands) {
-			fmt.Fprintf(os.Stderr, "%s %v\n", red("Error:"), err)
+			fmt.Fprintf(os.Stderr, "%s %v\n", ansi.Red("Error:"), err)
 		} else {
-			fmt.Fprintf(os.Stderr, "%s %v\n", red("Error:"), err)
+			fmt.Fprintf(os.Stderr, "%s %v\n", ansi.Red("Error:"), err)
 		}
 		os.Exit(1)
 	}
@@ -112,5 +108,5 @@ var (
 
     $ {{.Name}} -t 0 'sleep 5 && echo "hello"' 'sleep 2 && echo "world"'
 
-`, bold(name), dim("Commands:"), dim("Options:"), dim("Examples:"))
+`, ansi.Bold(name), ansi.Dim("Commands:"), ansi.Dim("Options:"), ansi.Dim("Examples:"))
 )

--- a/tandem/output.go
+++ b/tandem/output.go
@@ -1,4 +1,4 @@
-package main
+package tandem
 
 import (
 	"bufio"
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/pkg/term/termios"
+	"github.com/rosszurowski/tandem/ansi"
 )
 
 type ptyPipe struct {
@@ -73,15 +74,14 @@ func (m *multiOutput) WriteLine(proc *process, p []byte) {
 	var buf bytes.Buffer
 
 	if m.printProcName {
-		color := fmt.Sprintf("\033[0;38;5;%vm", proc.Color)
-		buf.WriteString(color)
+		buf.WriteString(ansi.ColorStart(proc.Color))
 		if m.printProcName {
 			buf.WriteString(proc.Name)
 			for i := len(proc.Name); i <= m.maxNameLength; i++ {
 				buf.WriteByte(' ')
 			}
 		}
-		buf.WriteString("\033[0m ")
+		buf.WriteString(ansi.ColorEnd() + " ")
 	}
 
 	// We trim the "/bin/sh: " prefix from the output of the command
@@ -96,7 +96,7 @@ func (m *multiOutput) WriteLine(proc *process, p []byte) {
 }
 
 func (m *multiOutput) WriteErr(proc *process, err error) {
-	m.WriteLine(proc, []byte(red(err.Error())))
+	m.WriteLine(proc, []byte(ansi.Red(err.Error())))
 }
 
 func scanLines(r io.Reader, callback func([]byte) bool) error {
@@ -137,23 +137,7 @@ func fatalOnErr(err error) {
 }
 
 func fatal(i ...interface{}) {
-	fmt.Fprint(os.Stderr, name+": ")
+	fmt.Fprint(os.Stderr, "tandem: ")
 	fmt.Fprintln(os.Stderr, i...)
 	os.Exit(1)
-}
-
-func red(s string) string {
-	return "\033[0;31m" + s + "\033[0m"
-}
-
-func gray(s string) string {
-	return "\033[0;38;5;8m" + s + "\033[0m"
-}
-
-func dim(s string) string {
-	return "\033[0;2m" + s + "\033[0m"
-}
-
-func bold(s string) string {
-	return "\033[1m" + s + "\033[0m"
 }


### PR DESCRIPTION
This commit splits tandem into a Go package and a CLI, letting users import the package and use it in their own Go programs.

Updates #5