### PR TITLE
Fix installation command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ brew install rosszurowski/tap/tandem
 If you have Go installed, you can install from the source with:
 
 ```shell
-go install github.com/rosszurowski/tandem@latest
+go install github.com/rosszurowski/tandem/cmd/tandem@latest
 ```
 
 If you're using tandem from a Makefile, [this snippet](#using-in-makefiles) shows how to download a locally cached copy.


### PR DESCRIPTION
The previous instructions we had were wrong because they didn't point directly to the binary file, they just pointed to the package. This commit fixes that. See #7.